### PR TITLE
Disable cookie banner

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -28,6 +28,7 @@
 		endif;
 		?>
 	</footer><!-- #colophon -->
+	<!--
 	<div class="cookies">
 		<div class="cookie-con">
 			<div class="cookie-content">
@@ -50,7 +51,7 @@
 			</div>
 		</div>
 	</div>
-		
+	-->	
 		
 
 </div><!-- #page -->


### PR DESCRIPTION
"It is not clear to me whether the pop-up should or should not be there given that the ORG website privacy notice is really not clear about their use of cookies, but the main site does not do the pop-up."