### PR TITLE
Ensure $posttypes is an array

### DIFF
--- a/page-roll.php
+++ b/page-roll.php
@@ -24,7 +24,8 @@ get_header(); ?>
 			<article>
 				<?php
 					if($_GET['filter'] && $_GET['filter'] != 'all') {
-						$urlVar = $posttypes = $_GET['filter'];
+						$posttypes = array($_GET['filter']);
+						$urlVar = $_GET['filter'];
 						 
 					} else {
 						$posttypes = array('workshop','story','ethical-review');


### PR DESCRIPTION
`$posttypes` should always be an `array` since a `count()` is applied

A request for `GET /workshops/?filter=workshop&pg=0` will result in the warning

```
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in .../wp-content/themes/virt-eu/page-roll.php on line 76
```